### PR TITLE
Fix duplicate results in GetAllProductIds

### DIFF
--- a/OpenSoftwareLauncher.Server/ContentManager.cs
+++ b/OpenSoftwareLauncher.Server/ContentManager.cs
@@ -328,7 +328,7 @@ namespace OpenSoftwareLauncher.Server
                 .Filter
                 .Empty;
 
-            return collection.Find(filter).ToList().Where(v => v.Release.appID.Length > 0).Select(v => v.Release.appID).ToArray();
+            return collection.Find(filter).ToList().Where(v => v.Release.appID.Length > 0).Select(v => v.Release.appID).Distinct().ToArray();
         }
     }
 }

--- a/OpenSoftwareLauncher.Server/Properties/Version.cs
+++ b/OpenSoftwareLauncher.Server/Properties/Version.cs
@@ -1,4 +1,4 @@
 ﻿using System.Reflection;
 
-[assembly: AssemblyVersion("1.2.0.0")]
-[assembly: AssemblyFileVersion("1.2.0.0")]
+[assembly: AssemblyVersion("1.2.0.1")]
+[assembly: AssemblyFileVersion("1.2.0.1")]

--- a/OpenSoftwareLauncher.Server/update.sh
+++ b/OpenSoftwareLauncher.Server/update.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+sudo systemctl stop buildapi.service
+
+rm -rf osltmp
+mkdir osltmp
+cd osltmp
+
+wget $1
+unzip *.zip
+rm *.zip
+
+cd ..
+
+
+mv OpenSoftwareLauncher.Server OpenSoftwareLauncher.Server.old
+rm osltmp/appsettings.*
+cp -rf osltmp/* ./
+
+sudo systemctl start buildapi.service


### PR DESCRIPTION
Fix duplicate entries in the returned array in `OpenSoftwareLauncher.Server.ContentManager.GetAllProductIds()`