### PR TITLE
Create "Superuser" account on startup

### DIFF
--- a/OSLCommon/Authorization/AccountManager.cs
+++ b/OSLCommon/Authorization/AccountManager.cs
@@ -14,6 +14,7 @@ namespace OSLCommon.Authorization
     public delegate void AccountDelegate(Account account);
     public partial class AccountManager
     {
+        public const string SuperuserUsername = "webmaster@osl.local";
         public List<Account> AccountList = new List<Account>();
 
         public static List<ITokenGranter> TokenGranters = new List<ITokenGranter>()


### PR DESCRIPTION
Creates a superuser account on startup when the following conditions are met
- Account `superuser@osl.local` doesn't exist
- `superuser@osl.local` has no tokens.

The token will be printed out to console and written to the text file `superuser-token.txt`