### PR TITLE
Use custom Attributes for permission validation

### DIFF
--- a/OpenSoftwareLauncher.Server/Controllers/Account/AccountController.cs
+++ b/OpenSoftwareLauncher.Server/Controllers/Account/AccountController.cs
@@ -6,6 +6,7 @@ namespace OpenSoftwareLauncher.Server.Controllers.Account
 {
     [Route("[controller]")]
     [ApiController]
+    [OSLAuthRequired]
     public class AccountController : Controller
     {
         [HttpGet("/account")]
@@ -14,12 +15,6 @@ namespace OpenSoftwareLauncher.Server.Controllers.Account
         [ProducesResponseType(401, Type = typeof(ObjectResponse<HttpException>))]
         public ActionResult AccountDetails(string token)
         {
-            var authRes = MainClass.Validate(token);
-            if (authRes != null)
-            {
-                Response.StatusCode = authRes?.Data.Code ?? 0;
-                return Json(authRes, MainClass.serializerOptions);
-            }
             var account = MainClass.contentManager.AccountManager.GetAccount(token, true);
 
             return Json(new ObjectResponse<AccountDetailsResponse>()

--- a/OpenSoftwareLauncher.Server/Controllers/Account/PermissionsController.cs
+++ b/OpenSoftwareLauncher.Server/Controllers/Account/PermissionsController.cs
@@ -6,17 +6,12 @@ namespace OpenSoftwareLauncher.Server.Controllers.Account
 {
     [Route("account/[controller]")]
     [ApiController]
+    [OSLAuthRequired]
     public class PermissionsController : Controller
     {
         [HttpGet]
         public ActionResult Index(string token)
         {
-            var authRes = MainClass.Validate(token);
-            if (authRes != null)
-            {
-                Response.StatusCode = authRes?.Data.Code ?? 0;
-                return Json(authRes, MainClass.serializerOptions);
-            }
             var account = MainClass.contentManager.AccountManager.GetAccount(token, true);
 
             return Json(new ObjectResponse<AccountPermission[]>()

--- a/OpenSoftwareLauncher.Server/Controllers/Account/TokenResetController.cs
+++ b/OpenSoftwareLauncher.Server/Controllers/Account/TokenResetController.cs
@@ -5,6 +5,7 @@ namespace OpenSoftwareLauncher.Server.Controllers.Account
 {
     [Route("account/token")]
     [ApiController]
+    [OSLAuthRequired]
     public class TokenResetController : Controller
     {
         [HttpGet("reset")]
@@ -12,12 +13,6 @@ namespace OpenSoftwareLauncher.Server.Controllers.Account
         [ProducesResponseType(200, Type = typeof(ObjectResponse<int>))]
         public ActionResult TokenReset(string token, bool allButSupplied=true, bool all=false)
         {
-            var authRes = MainClass.Validate(token);
-            if (authRes != null)
-            {
-                Response.StatusCode = authRes?.Data.Code ?? 0;
-                return Json(authRes, MainClass.serializerOptions);
-            }
             var account = MainClass.contentManager.AccountManager.GetAccount(token, true);
 
             int tokensRemoved = 0;

--- a/OpenSoftwareLauncher.Server/Controllers/Admin/AuditLogController.cs
+++ b/OpenSoftwareLauncher.Server/Controllers/Admin/AuditLogController.cs
@@ -10,25 +10,15 @@ namespace OpenSoftwareLauncher.Server.Controllers.Admin
 {
     [Route("admin/auditlog")]
     [ApiController]
+    [OSLAuthRequired]
+    [OSLAuthPermission(AccountPermission.AUDITLOG_GLOBAL)]
     public class AuditLogController : Controller
     {
-        public static AccountPermission[] RequiredPermissions = new AccountPermission[]
-        {
-            AccountPermission.AUDITLOG_GLOBAL
-        };
-
         [HttpGet("all")]
         [ProducesResponseType(200, Type = typeof(ObjectResponse<AuditLogEntry[]>))]
         [ProducesResponseType(401, Type = typeof(ObjectResponse<HttpException>))]
         public ActionResult FetchAll(string token)
         {
-            var authRes = MainClass.ValidatePermissions(token, RequiredPermissions);
-            if (authRes != null)
-            {
-                Response.StatusCode = authRes?.Data.Code ?? 0;
-                return Json(authRes, MainClass.serializerOptions);
-            }
-
             var result = MainClass.contentManager.AuditLogManager.GetAll().Result;
 
             return Json(new ObjectResponse<AuditLogEntry[]>()
@@ -43,13 +33,6 @@ namespace OpenSoftwareLauncher.Server.Controllers.Admin
         [ProducesResponseType(401, Type = typeof(ObjectResponse<HttpException>))]
         public ActionResult FetchByAction(string token, AuditType auditType)
         {
-            var authRes = MainClass.ValidatePermissions(token, RequiredPermissions);
-            if (authRes != null)
-            {
-                Response.StatusCode = authRes?.Data.Code ?? 0;
-                return Json(authRes, MainClass.serializerOptions);
-            }
-
             var result = MainClass.contentManager.AuditLogManager.GetByType(auditType).Result;
 
             return Json(new ObjectResponse<AuditLogEntry[]>()
@@ -64,13 +47,6 @@ namespace OpenSoftwareLauncher.Server.Controllers.Admin
         [ProducesResponseType(401, Type = typeof(ObjectResponse<HttpException>))]
         public ActionResult FetchByAccount(string token, string? username = null)
         {
-            var authRes = MainClass.ValidatePermissions(token, RequiredPermissions);
-            if (authRes != null)
-            {
-                Response.StatusCode = authRes?.Data.Code ?? 0;
-                return Json(authRes, MainClass.serializerOptions);
-            }
-
             AuditLogEntry[] result;
             if (username == null)
             {
@@ -95,13 +71,6 @@ namespace OpenSoftwareLauncher.Server.Controllers.Admin
         [ProducesResponseType(401, Type = typeof(ObjectResponse<HttpException>))]
         public ActionResult FetchByTimestampRange(string token, long min, long max, AuditType auditType = AuditType.Any)
         {
-            var authRes = MainClass.ValidatePermissions(token, RequiredPermissions);
-            if (authRes != null)
-            {
-                Response.StatusCode = authRes?.Data.Code ?? 0;
-                return Json(authRes, MainClass.serializerOptions);
-            }
-
             AuditLogEntry[] result = MainClass.contentManager.AuditLogManager.GetWithFilter(
                 Builders<AuditLogEntry>
                     .Filter

--- a/OpenSoftwareLauncher.Server/Controllers/Admin/Bot/BotListingController.cs
+++ b/OpenSoftwareLauncher.Server/Controllers/Admin/Bot/BotListingController.cs
@@ -7,6 +7,8 @@ namespace OpenSoftwareLauncher.Server.Controllers.Admin.Bot
 {
     [Route("admin/bot")]
     [ApiController]
+    [OSLAuthRequired]
+    [OSLAuthPermission(AccountPermission.ADMINISTRATOR)]
     public class BotListingController : Controller
     {
         /// <summary>
@@ -27,12 +29,6 @@ namespace OpenSoftwareLauncher.Server.Controllers.Admin.Bot
                 Data = new HttpException(StatusCodes.Status403Forbidden, @"Not Implemented")
             }, MainClass.serializerOptions);
 #endif
-            var authRes = MainClass.ValidatePermissions(token, AccountPermission.ADMINISTRATOR);
-            if (authRes != null)
-            {
-                Response.StatusCode = authRes?.Data.Code ?? 0;
-                return Json(authRes, MainClass.serializerOptions);
-            }
             return Json(new ObjectResponse<object>()
             {
                 Success = true,

--- a/OpenSoftwareLauncher.Server/Controllers/Admin/ConfigController.cs
+++ b/OpenSoftwareLauncher.Server/Controllers/Admin/ConfigController.cs
@@ -13,25 +13,16 @@ namespace OpenSoftwareLauncher.Server.Controllers.Admin
 {
     [Route("admin/[controller]")]
     [ApiController]
+    [OSLAuthRequired]
+    [OSLAuthPermission(AccountPermission.ADMINISTRATOR)]
     public class ConfigController : Controller
     {
-        public static AccountPermission[] RequiredPermissions = new AccountPermission[]
-        {
-            AccountPermission.ADMINISTRATOR
-        };
 
         [HttpGet("get")]
         [ProducesResponseType(200, Type = typeof(ObjectResponse<Dictionary<string, Dictionary<string, object>>>))]
         [ProducesResponseType(401, Type = typeof(ObjectResponse<HttpException>))]
         public ActionResult GetConfig(string token)
         {
-            var authRes = MainClass.ValidatePermissions(token, RequiredPermissions);
-            if (authRes != null)
-            {
-                Response.StatusCode = authRes?.Data.Code ?? 0;
-                return Json(authRes, MainClass.serializerOptions);
-            }
-
             return Json(new ObjectResponse<Dictionary<string, Dictionary<string, object>>>()
             {
                 Data = ServerConfig.Get(),
@@ -46,35 +37,6 @@ namespace OpenSoftwareLauncher.Server.Controllers.Admin
         [ProducesResponseType(401, Type = typeof(ObjectResponse<HttpException>))]
         public ActionResult SetValue_Get(string token, string group, string key, object value)
         {
-            if (!MainClass.contentManager.AccountManager.AccountHasPermission(token, RequiredPermissions))
-            {
-                Response.StatusCode = StatusCodes.Status401Unauthorized;
-                return Json(new ObjectResponse<HttpException>()
-                {
-                    Success = false,
-                    Data = new HttpException(401, ServerStringResponse.InvalidCredential)
-                }, MainClass.serializerOptions);
-            }
-            var tokenAccount = MainClass.contentManager.AccountManager.GetAccount(token, bumpLastUsed: true);
-            if (tokenAccount == null)
-            {
-                Response.StatusCode = StatusCodes.Status401Unauthorized;
-                return Json(new ObjectResponse<HttpException>()
-                {
-                    Success = false,
-                    Data = new HttpException(401, ServerStringResponse.InvalidCredential)
-                }, MainClass.serializerOptions);
-            }
-            if (!tokenAccount.Enabled)
-            {
-                Response.StatusCode = StatusCodes.Status401Unauthorized;
-                return Json(new ObjectResponse<HttpException>()
-                {
-                    Success = false,
-                    Data = new HttpException(401, ServerStringResponse.AccountDisabled)
-                }, MainClass.serializerOptions);
-            }
-
             ServerConfig.Set(group, key, value);
 
             return Json(new ObjectResponse<Dictionary<string, Dictionary<string, object>>>()
@@ -90,14 +52,6 @@ namespace OpenSoftwareLauncher.Server.Controllers.Admin
         [ProducesResponseType(401, Type = typeof(ObjectResponse<HttpException>))]
         public ActionResult SetValue(string token, string group, string key)
         {
-            var authRes = MainClass.ValidatePermissions(token, RequiredPermissions);
-            if (authRes != null)
-            {
-                Response.StatusCode = authRes?.Data.Code ?? 0;
-                return Json(authRes, MainClass.serializerOptions);
-            }
-
-
             var syncIOFeature = HttpContext.Features.Get<IHttpBodyControlFeature>();
             if (syncIOFeature != null)
             {
@@ -135,14 +89,6 @@ namespace OpenSoftwareLauncher.Server.Controllers.Admin
         [ProducesResponseType(401, Type = typeof(ObjectResponse<HttpException>))]
         public ActionResult SetConfig(string token)
         {
-            var authRes = MainClass.ValidatePermissions(token, RequiredPermissions);
-            if (authRes != null)
-            {
-                Response.StatusCode = authRes?.Data.Code ?? 0;
-                return Json(authRes, MainClass.serializerOptions);
-            }
-
-
             var syncIOFeature = HttpContext.Features.Get<IHttpBodyControlFeature>();
             if (syncIOFeature != null)
             {
@@ -189,13 +135,6 @@ namespace OpenSoftwareLauncher.Server.Controllers.Admin
         [ProducesResponseType(500, Type = typeof(ObjectResponse<HttpException>))]
         public ActionResult ResetConfig(string token)
         {
-            var authRes = MainClass.ValidatePermissions(token, RequiredPermissions);
-            if (authRes != null)
-            {
-                Response.StatusCode = authRes?.Data.Code ?? 0;
-                return Json(authRes, MainClass.serializerOptions);
-            }
-
             try
             {
                 ServerConfig.Set(ServerConfig.DefaultData);
@@ -222,13 +161,6 @@ namespace OpenSoftwareLauncher.Server.Controllers.Admin
         [ProducesResponseType(401, Type = typeof(ObjectResponse<HttpException>))]
         public ActionResult Save(string token)
         {
-            var authRes = MainClass.ValidatePermissions(token, RequiredPermissions);
-            if (authRes != null)
-            {
-                Response.StatusCode = authRes?.Data.Code ?? 0;
-                return Json(authRes, MainClass.serializerOptions);
-            }
-
             ServerConfig.Save();
 
             return Json(new ObjectResponse<Dictionary<string, Dictionary<string, object>>>()

--- a/OpenSoftwareLauncher.Server/Controllers/Admin/DataController.cs
+++ b/OpenSoftwareLauncher.Server/Controllers/Admin/DataController.cs
@@ -15,13 +15,10 @@ namespace OpenSoftwareLauncher.Server.Controllers.Admin
 
     [Route("admin/[controller]")]
     [ApiController]
+    [OSLAuthRequired]
+    [OSLAuthPermission(AccountPermission.ADMINISTRATOR)]
     public class DataController : Controller
     {
-        public static AccountPermission[] RequiredPermissions = new AccountPermission[]
-        {
-            AccountPermission.ADMINISTRATOR
-        };
-
         [HttpPost("restore")]
         [ProducesResponseType(200, Type = typeof(ObjectResponse<DataJSON>))]
         [ProducesResponseType(400, Type = typeof(ObjectResponse<HttpException>))]
@@ -29,13 +26,6 @@ namespace OpenSoftwareLauncher.Server.Controllers.Admin
         [ProducesResponseType(500, Type = typeof(ObjectResponse<HttpException>))]
         public ActionResult Restore(string token)
         {
-            var authRes = MainClass.ValidatePermissions(token, RequiredPermissions);
-            if (authRes != null)
-            {
-                Response.StatusCode = authRes?.Data.Code ?? 0;
-                return Json(authRes, MainClass.serializerOptions);
-            }
-
             HttpContext.Request.Body.Seek(0, SeekOrigin.Begin);
             string content = new StreamReader(HttpContext.Request.Body).ReadToEndAsync().Result.ReplaceLineEndings("");
 
@@ -115,12 +105,6 @@ namespace OpenSoftwareLauncher.Server.Controllers.Admin
         [ProducesResponseType(500, Type = typeof(ObjectResponse<HttpException>))]
         public ActionResult Fetch(string token)
         {
-            var authRes = MainClass.ValidatePermissions(token, RequiredPermissions);
-            if (authRes != null)
-            {
-                Response.StatusCode = authRes?.Data.Code ?? 0;
-                return Json(authRes, MainClass.serializerOptions);
-            }
 
             DataJSON content;
 
@@ -161,12 +145,6 @@ namespace OpenSoftwareLauncher.Server.Controllers.Admin
         [ProducesResponseType(401, Type = typeof(ObjectResponse<HttpException>))]
         public ActionResult Dump(string token, DataType type)
         {
-            var authRes = MainClass.ValidatePermissions(token, RequiredPermissions);
-            if (authRes != null)
-            {
-                Response.StatusCode = authRes?.Data.Code ?? 0;
-                return Json(authRes, MainClass.serializerOptions);
-            }
 
             if (type == DataType.All)
             {
@@ -213,12 +191,6 @@ namespace OpenSoftwareLauncher.Server.Controllers.Admin
         [ProducesResponseType(401, Type = typeof(ObjectResponse<HttpException>))]
         public ActionResult SetData(string token)
         {
-            var authRes = MainClass.ValidatePermissions(token, RequiredPermissions);
-            if (authRes != null)
-            {
-                Response.StatusCode = authRes?.Data.Code ?? 0;
-                return Json(authRes, MainClass.serializerOptions);
-            }
 
             HttpContext.Request.Body.Seek(0, SeekOrigin.Begin);
             string content = new StreamReader(HttpContext.Request.Body).ReadToEndAsync().Result.ReplaceLineEndings("");

--- a/OpenSoftwareLauncher.Server/Controllers/Admin/LicenseController.cs
+++ b/OpenSoftwareLauncher.Server/Controllers/Admin/LicenseController.cs
@@ -18,26 +18,16 @@ namespace OpenSoftwareLauncher.Server.Controllers.Admin
 {
     [Route("admin/license")]
     [ApiController]
+    [OSLAuthRequired]
+    [OSLAuthPermission(AccountPermission.LICENSE_MANAGE)]
     public class LicenseController : Controller
     {
-        public static AccountPermission[] RequiredPermissions = new AccountPermission[]
-        {
-            AccountPermission.LICENSE_MANAGE,
-        };
-
         [HttpPost("generateProductKey")]
         [ProducesResponseType(200, Type = typeof(ObjectResponse<CreateLicenseKeyResponse>))]
         [ProducesResponseType(400, Type = typeof(ObjectResponse<HttpException>))]
         [ProducesResponseType(401, Type = typeof(ObjectResponse<HttpException>))]
         public ActionResult CreateProductKey(string token)
         {
-            var authRes = MainClass.ValidatePermissions(token, RequiredPermissions);
-            if (authRes != null)
-            {
-                Response.StatusCode = authRes?.Data.Code ?? 0;
-                return Json(authRes, MainClass.serializerOptions);
-            }
-
             var account = MainClass.contentManager.AccountManager.GetAccount(token);
 
 
@@ -105,13 +95,6 @@ namespace OpenSoftwareLauncher.Server.Controllers.Admin
         [ProducesResponseType(401, Type = typeof(ObjectResponse<HttpException>))]
         public ActionResult GetLicenseKeys(string token)
         {
-            var authRes = MainClass.ValidatePermissions(token, RequiredPermissions);
-            if (authRes != null)
-            {
-                Response.StatusCode = authRes?.Data.Code ?? 0;
-                return Json(authRes, MainClass.serializerOptions);
-            }
-
             return Json(new ObjectResponse<LicenseKeyMetadata[]>
             {
                 Success = true,
@@ -124,13 +107,6 @@ namespace OpenSoftwareLauncher.Server.Controllers.Admin
         [ProducesResponseType(401, Type = typeof(ObjectResponse<HttpException>))]
         public ActionResult GetProductLicenseKeys(string token, string remoteLocation)
         {
-            var authRes = MainClass.ValidatePermissions(token, RequiredPermissions);
-            if (authRes != null)
-            {
-                Response.StatusCode = authRes?.Data.Code ?? 0;
-                return Json(authRes, MainClass.serializerOptions);
-            }
-
             var keys = MainClass.contentManager.AccountLicenseManager.GetLicenseKeys().Result
                 .Where(v => v.Products.Contains(remoteLocation))
                 .ToArray();
@@ -155,13 +131,6 @@ namespace OpenSoftwareLauncher.Server.Controllers.Admin
         [ProducesResponseType(401, Type = typeof(ObjectResponse<HttpException>))]
         public ActionResult DisableKey(string token, string keyId)
         {
-            var authRes = MainClass.ValidatePermissions(token, RequiredPermissions);
-            if (authRes != null)
-            {
-                Response.StatusCode = authRes?.Data.Code ?? 0;
-                return Json(authRes, MainClass.serializerOptions);
-            }
-
             LicenseKeyActionResult response = MainClass.contentManager.AccountLicenseManager.DisableLicenseKey(keyId).Result;
 
             var account = MainClass.contentManager.AccountManager.GetAccount(token);
@@ -182,13 +151,6 @@ namespace OpenSoftwareLauncher.Server.Controllers.Admin
         [ProducesResponseType(401, Type = typeof(ObjectResponse<HttpException>))]
         public ActionResult EnableKey(string token, string keyId)
         {
-            var authRes = MainClass.ValidatePermissions(token, RequiredPermissions);
-            if (authRes != null)
-            {
-                Response.StatusCode = authRes?.Data.Code ?? 0;
-                return Json(authRes, MainClass.serializerOptions);
-            }
-
             LicenseKeyActionResult response = MainClass.contentManager.AccountLicenseManager.EnableLicenseKey(keyId).Result;
 
             var account = MainClass.contentManager.AccountManager.GetAccount(token);

--- a/OpenSoftwareLauncher.Server/Controllers/Admin/ReleaseController.cs
+++ b/OpenSoftwareLauncher.Server/Controllers/Admin/ReleaseController.cs
@@ -11,13 +11,10 @@ namespace OpenSoftwareLauncher.Server.Controllers.Admin
 {
     [Route("admin/release")]
     [ApiController]
+    [OSLAuthRequired]
+    [OSLAuthPermission(AccountPermission.RELEASE_MANAGE)]
     public class ReleaseController : Controller
     {
-        public static AccountPermission[] RequiredPermissions = new AccountPermission[]
-        {
-            AccountPermission.RELEASE_MANAGE
-        };
-
         private async Task<long> DeleteFilter(FilterDefinition<ReleaseInfo> releaseFilter, FilterDefinition<PublishedRelease> publishedFilter)
         {
             var publishedCollection = MainClass.contentManager.GetPublishedCollection();
@@ -37,13 +34,6 @@ namespace OpenSoftwareLauncher.Server.Controllers.Admin
         [ProducesResponseType(401, Type = typeof(ObjectResponse<HttpException>))]
         public async Task<ActionResult> Get_ReleaseInfo(string token)
         {
-            var authRes = MainClass.ValidatePermissions(token, RequiredPermissions);
-            if (authRes != null)
-            {
-                Response.StatusCode = authRes?.Data.Code ?? 0;
-                return Json(authRes, MainClass.serializerOptions);
-            }
-
             var filter = Builders<ReleaseInfo>
                 .Filter
                 .Empty;
@@ -67,13 +57,6 @@ namespace OpenSoftwareLauncher.Server.Controllers.Admin
         [ProducesResponseType(401, Type = typeof(ObjectResponse<HttpException>))]
         public async Task<ActionResult> Signature_Delete(string token, string signature)
         {
-            var authRes = MainClass.ValidatePermissions(token, RequiredPermissions);
-            if (authRes != null)
-            {
-                Response.StatusCode = authRes?.Data.Code ?? 0;
-                return Json(authRes, MainClass.serializerOptions);
-            }
-
 
             var publishedFilter = Builders<PublishedRelease>
                 .Filter
@@ -96,14 +79,6 @@ namespace OpenSoftwareLauncher.Server.Controllers.Admin
         [ProducesResponseType(401, Type = typeof(ObjectResponse<HttpException>))]
         public async Task<ActionResult> Signature_Get_ReleaseInfo(string token, string signature)
         {
-            var authRes = MainClass.ValidatePermissions(token, RequiredPermissions);
-            if (authRes != null)
-            {
-                Response.StatusCode = authRes?.Data.Code ?? 0;
-                return Json(authRes, MainClass.serializerOptions);
-            }
-
-
             var filter = Builders<ReleaseInfo>
                 .Filter
                 .Where(v => v.remoteLocation == signature);
@@ -126,13 +101,6 @@ namespace OpenSoftwareLauncher.Server.Controllers.Admin
         [ProducesResponseType(401, Type = typeof(ObjectResponse<HttpException>))]
         public async Task<ActionResult> Signature_Get_PublishedRelease(string token, string signature)
         {
-            var authRes = MainClass.ValidatePermissions(token, RequiredPermissions);
-            if (authRes != null)
-            {
-                Response.StatusCode = authRes?.Data.Code ?? 0;
-                return Json(authRes, MainClass.serializerOptions);
-            }
-
             var filter = Builders<PublishedRelease>
                 .Filter
                 .Where(v => v.RemoteLocation == signature);
@@ -156,13 +124,6 @@ namespace OpenSoftwareLauncher.Server.Controllers.Admin
         [ProducesResponseType(401, Type = typeof(ObjectResponse<HttpException>))]
         public async Task<ActionResult> CommitHash_Delete(string token, string hash)
         {
-            var authRes = MainClass.ValidatePermissions(token, RequiredPermissions);
-            if (authRes != null)
-            {
-                Response.StatusCode = authRes?.Data.Code ?? 0;
-                return Json(authRes, MainClass.serializerOptions);
-            }
-
             var publishedFilter = Builders<PublishedRelease>
                 .Filter
                 .Where(v => v.CommitHash == hash);
@@ -184,13 +145,6 @@ namespace OpenSoftwareLauncher.Server.Controllers.Admin
         [ProducesResponseType(401, Type = typeof(ObjectResponse<HttpException>))]
         public async Task<ActionResult> CommitHash_Get_ReleaseInfo(string token, string hash)
         {
-            var authRes = MainClass.ValidatePermissions(token, RequiredPermissions);
-            if (authRes != null)
-            {
-                Response.StatusCode = authRes?.Data.Code ?? 0;
-                return Json(authRes, MainClass.serializerOptions);
-            }
-
             var filter = Builders<ReleaseInfo>
                 .Filter
                 .Where(v => v.commitHash == hash);
@@ -213,14 +167,6 @@ namespace OpenSoftwareLauncher.Server.Controllers.Admin
         [ProducesResponseType(401, Type = typeof(ObjectResponse<HttpException>))]
         public async Task<ActionResult> CommitHash_Get_PublishedRelease(string token, string hash)
         {
-            var authRes = MainClass.ValidatePermissions(token, RequiredPermissions);
-            if (authRes != null)
-            {
-                Response.StatusCode = authRes?.Data.Code ?? 0;
-                return Json(authRes, MainClass.serializerOptions);
-            }
-
-
             var filter = Builders<PublishedRelease>
                 .Filter
                 .Where(v => v.CommitHash == hash);

--- a/OpenSoftwareLauncher.Server/Controllers/Admin/ServiceAccountController.cs
+++ b/OpenSoftwareLauncher.Server/Controllers/Admin/ServiceAccountController.cs
@@ -14,27 +14,16 @@ namespace OpenSoftwareLauncher.Server.Controllers.Admin
 {
     [Route("admin/serviceaccount")]
     [ApiController]
+    [OSLAuthRequired]
+    [OSLAuthPermission(AccountPermission.SERVICEACCOUNT_MANAGE)]
     public class ServiceAccountController : Controller
     {
-        public static AccountPermission[] RequiredPermissions = new AccountPermission[]
-        {
-            AccountPermission.SERVICEACCOUNT_MANAGE,
-        };
-
         [HttpPost("create")]
         [ProducesResponseType(200, Type = typeof(ObjectResponse<GrantTokenResponse>))]
         [ProducesResponseType(400, Type = typeof(ObjectResponse<HttpException>))]
         [ProducesResponseType(401, Type = typeof(ObjectResponse<HttpException>))]
         public ActionResult CreateAccount(string token)
         {
-            var authRes = MainClass.ValidatePermissions(token, RequiredPermissions);
-            if (authRes != null)
-            {
-                Response.StatusCode = authRes?.Data.Code ?? 0;
-                return Json(authRes, MainClass.serializerOptions);
-            }
-
-
             var syncIOFeature = HttpContext.Features.Get<IHttpBodyControlFeature>();
             if (syncIOFeature != null)
             {

--- a/OpenSoftwareLauncher.Server/Controllers/Admin/SystemAnnouncement.cs
+++ b/OpenSoftwareLauncher.Server/Controllers/Admin/SystemAnnouncement.cs
@@ -14,10 +14,6 @@ namespace OpenSoftwareLauncher.Server.Controllers.Admin
     [ApiController]
     public class SystemAnnouncementController : Controller
     {
-        public static AccountPermission[] RequiredPermissions = new AccountPermission[]
-        {
-            AccountPermission.ANNOUNCEMENT_MANAGE
-        };
         [HttpGet("latest")]
         [ProducesResponseType(200, Type = typeof(ObjectResponse<SystemAnnouncementEntry[]>))]
         public ActionResult Fetch()
@@ -36,14 +32,10 @@ namespace OpenSoftwareLauncher.Server.Controllers.Admin
         [HttpGet("new")]
         [ProducesResponseType(200, Type = typeof(ObjectResponse<SystemAnnouncementSummary>))]
         [ProducesResponseType(401, Type = typeof(ObjectResponse<HttpException>))]
+        [OSLAuthRequired]
+        [OSLAuthPermission(AccountPermission.ANNOUNCEMENT_MANAGE)]
         public ActionResult Set(string token, string content, bool? active=true)
         {
-            var authRes = MainClass.ValidatePermissions(token, RequiredPermissions);
-            if (authRes != null)
-            {
-                Response.StatusCode = authRes?.Data.Code ?? 0;
-                return Json(authRes, MainClass.serializerOptions);
-            }
             var account = MainClass.contentManager.AccountManager.GetAccount(token);
             var announcement = MainClass.contentManager.SystemAnnouncement.Set(content, active ?? true);
             MainClass.contentManager.AuditLogManager.Create(new AnnouncementCreateEntryData(announcement), account).Wait();
@@ -58,14 +50,10 @@ namespace OpenSoftwareLauncher.Server.Controllers.Admin
         [HttpGet("update")]
         [ProducesResponseType(200, Type = typeof(ObjectResponse<object?>))]
         [ProducesResponseType(401, Type = typeof(ObjectResponse<HttpException>))]
+        [OSLAuthRequired]
+        [OSLAuthPermission(AccountPermission.ANNOUNCEMENT_MANAGE)]
         public ActionResult UpdateActiveStatus(string token, bool active)
         {
-            var authRes = MainClass.ValidatePermissions(token, RequiredPermissions);
-            if (authRes != null)
-            {
-                Response.StatusCode = authRes?.Data.Code ?? 0;
-                return Json(authRes, MainClass.serializerOptions);
-            }
             var account = MainClass.contentManager.AccountManager.GetAccount(token);
 
             MainClass.contentManager.SystemAnnouncement.Active = active;
@@ -84,14 +72,10 @@ namespace OpenSoftwareLauncher.Server.Controllers.Admin
         [HttpGet("all")]
         [ProducesResponseType(200, Type = typeof(ObjectResponse<SystemAnnouncementEntry[]>))]
         [ProducesResponseType(401, Type = typeof(ObjectResponse<HttpException>))]
+        [OSLAuthRequired]
+        [OSLAuthPermission(AccountPermission.ANNOUNCEMENT_MANAGE)]
         public ActionResult FetchAll(string token)
         {
-            var authRes = MainClass.ValidatePermissions(token, RequiredPermissions);
-            if (authRes != null)
-            {
-                Response.StatusCode = authRes?.Data.Code ?? 0;
-                return Json(authRes, MainClass.serializerOptions);
-            }
             return Json(new ObjectResponse<SystemAnnouncementEntry[]>()
             {
                 Success = true,
@@ -102,14 +86,10 @@ namespace OpenSoftwareLauncher.Server.Controllers.Admin
         [HttpGet("summary")]
         [ProducesResponseType(200, Type = typeof(ObjectResponse<SystemAnnouncementSummary>))]
         [ProducesResponseType(401, Type = typeof(ObjectResponse<HttpException>))]
+        [OSLAuthRequired]
+        [OSLAuthPermission(AccountPermission.ANNOUNCEMENT_MANAGE)]
         public ActionResult GetSummary(string token)
         {
-            var authRes = MainClass.ValidatePermissions(token, RequiredPermissions);
-            if (authRes != null)
-            {
-                Response.StatusCode = authRes?.Data.Code ?? 0;
-                return Json(authRes, MainClass.serializerOptions);
-            }
             return Json(new ObjectResponse<SystemAnnouncementSummary>()
             {
                 Success = true,
@@ -121,14 +101,10 @@ namespace OpenSoftwareLauncher.Server.Controllers.Admin
         [HttpGet("setData")]
         [ProducesResponseType(200, Type = typeof(ObjectResponse<SystemAnnouncementSummary>))]
         [ProducesResponseType(401, Type = typeof(ObjectResponse<HttpException>))]
+        [OSLAuthRequired]
+        [OSLAuthPermission(AccountPermission.ANNOUNCEMENT_MANAGE)]
         public ActionResult SetData(string token, string content)
         {
-            var authRes = MainClass.ValidatePermissions(token, RequiredPermissions);
-            if (authRes != null)
-            {
-                Response.StatusCode = authRes?.Data.Code ?? 0;
-                return Json(authRes, MainClass.serializerOptions);
-            }
             var account = MainClass.contentManager.AccountManager.GetAccount(token);
 
             var attemptedDeserialized = JsonSerializer.Deserialize<SystemAnnouncementSummary>(content, MainClass.serializerOptions);
@@ -199,14 +175,10 @@ namespace OpenSoftwareLauncher.Server.Controllers.Admin
         [HttpGet("remove")]
         [ProducesResponseType(200, Type = typeof(ObjectResponse<SystemAnnouncementSummary>))]
         [ProducesResponseType(401, Type = typeof(ObjectResponse<HttpException>))]
+        [OSLAuthRequired]
+        [OSLAuthPermission(AccountPermission.ANNOUNCEMENT_MANAGE)]
         public ActionResult RemoveAnnouncement(string token, string id)
         {
-            var authRes = MainClass.ValidatePermissions(token, RequiredPermissions);
-            if (authRes != null)
-            {
-                Response.StatusCode = authRes?.Data.Code ?? 0;
-                return Json(authRes, MainClass.serializerOptions);
-            }
             var account = MainClass.contentManager.AccountManager.GetAccount(token);
 
             bool exists = MainClass.contentManager.SystemAnnouncement.GetAll().Where(v => v.ID == id).Count() > 0;

--- a/OpenSoftwareLauncher.Server/Controllers/Admin/User/UserGroupController.cs
+++ b/OpenSoftwareLauncher.Server/Controllers/Admin/User/UserGroupController.cs
@@ -12,26 +12,16 @@ namespace OpenSoftwareLauncher.Server.Controllers.Admin.User
 {
     [Route("admin/user/group")]
     [ApiController]
+    [OSLAuthRequired]
+    [OSLAuthPermission(AccountPermission.USER_GROUP_MODIFY)]
+    [ProducesResponseType(401, Type = typeof(ObjectResponse<HttpException>))]
     public class UserGroupController : Controller
     {
-        public static AccountPermission[] RequiredPermissions = new AccountPermission[]
-        {
-            AccountPermission.USER_GROUP_MODIFY
-        };
-
         [HttpGet("list")]
         [ProducesResponseType(200, Type = typeof(ObjectResponse<string[]>))]
-        [ProducesResponseType(401, Type = typeof(ObjectResponse<HttpException>))]
         [ProducesResponseType(404, Type = typeof(ObjectResponse<HttpException>))]
         public ActionResult List(string token, string username)
         {
-            var authRes = MainClass.ValidatePermissions(token, RequiredPermissions);
-            if (authRes != null)
-            {
-                Response.StatusCode = authRes?.Data.Code ?? 0;
-                return Json(authRes, MainClass.serializerOptions);
-            }
-
             var targetAccount = MainClass.contentManager.AccountManager.GetAccountByUsername(username);
             if (targetAccount == null)
             {
@@ -52,18 +42,9 @@ namespace OpenSoftwareLauncher.Server.Controllers.Admin.User
 
         [HttpPost("set")]
         [ProducesResponseType(200, Type = typeof(ObjectResponse<object>))]
-        [ProducesResponseType(401, Type = typeof(ObjectResponse<HttpException>))]
         [ProducesResponseType(500, Type = typeof(ObjectResponse<HttpException>))]
         public ActionResult SetContent(string token)
         {
-            var authRes = MainClass.ValidatePermissions(token, RequiredPermissions);
-            if (authRes != null)
-            {
-                Response.StatusCode = authRes?.Data.Code ?? 0;
-                return Json(authRes, MainClass.serializerOptions);
-            }
-
-
             var syncIOFeature = HttpContext.Features.Get<IHttpBodyControlFeature>();
             if (syncIOFeature != null)
             {
@@ -118,17 +99,9 @@ namespace OpenSoftwareLauncher.Server.Controllers.Admin.User
 
         [HttpGet("grant")]
         [ProducesResponseType(200, Type = typeof(ObjectResponse<bool>))]
-        [ProducesResponseType(401, Type = typeof(ObjectResponse<HttpException>))]
         [ProducesResponseType(404, Type = typeof(ObjectResponse<HttpException>))]
         public ActionResult Grant(string token, string username, string group)
         {
-            var authRes = MainClass.ValidatePermissions(token, RequiredPermissions);
-            if (authRes != null)
-            {
-                Response.StatusCode = authRes?.Data.Code ?? 0;
-                return Json(authRes, MainClass.serializerOptions);
-            }
-
             var account = MainClass.contentManager.AccountManager.GetAccountByUsername(username);
             if (account == null)
             {
@@ -149,17 +122,9 @@ namespace OpenSoftwareLauncher.Server.Controllers.Admin.User
 
         [HttpGet("revoke")]
         [ProducesResponseType(200, Type = typeof(ObjectResponse<object>))]
-        [ProducesResponseType(401, Type = typeof(ObjectResponse<HttpException>))]
         [ProducesResponseType(404, Type = typeof(ObjectResponse<HttpException>))]
         public ActionResult RevokeGroup(string token, string username, string group)
         {
-            var authRes = MainClass.ValidatePermissions(token, RequiredPermissions);
-            if (authRes != null)
-            {
-                Response.StatusCode = authRes?.Data.Code ?? 0;
-                return Json(authRes, MainClass.serializerOptions);
-            }
-
             var account = MainClass.contentManager.AccountManager.GetAccountByUsername(username);
             if (account == null)
             {

--- a/OpenSoftwareLauncher.Server/Controllers/Admin/User/UserLicenseController.cs
+++ b/OpenSoftwareLauncher.Server/Controllers/Admin/User/UserLicenseController.cs
@@ -9,25 +9,17 @@ namespace OpenSoftwareLauncher.Server.Controllers.Admin.User
 {
     [Route("admin/user/license")]
     [ApiController]
+    [OSLAuthRequired]
+    [OSLAuthPermission(AccountPermission.USER_LICENSE_MODIFY)]
+    [ProducesResponseType(401, Type = typeof(ObjectResponse<HttpException>))]
+    [ProducesResponseType(404, Type = typeof(ObjectResponse<HttpException>))]
+    [ProducesResponseType(409, Type = typeof(ObjectResponse<HttpException>))]
     public class UserLicenseController : Controller
     {
-        public static AccountPermission[] RequiredPermissions = new AccountPermission[]
-        {
-            AccountPermission.USER_LICENSE_MODIFY
-        };
         [HttpGet("grant")]
         [ProducesResponseType(200, Type = typeof(ObjectResponse<string[]>))]
-        [ProducesResponseType(401, Type = typeof(ObjectResponse<HttpException>))]
-        [ProducesResponseType(404, Type = typeof(ObjectResponse<HttpException>))]
-        [ProducesResponseType(409, Type = typeof(ObjectResponse<HttpException>))]
         public ActionResult Grant(string token, string username, string license)
         {
-            var authRes = MainClass.ValidatePermissions(token, RequiredPermissions);
-            if (authRes != null)
-            {
-                Response.StatusCode = authRes?.Data.Code ?? 0;
-                return Json(authRes, MainClass.serializerOptions);
-            }
             var tokenAccount = MainClass.contentManager.AccountManager.GetAccount(token, false);
 
             var account = MainClass.contentManager.AccountManager.GetAccountByUsername(username);
@@ -62,17 +54,8 @@ namespace OpenSoftwareLauncher.Server.Controllers.Admin.User
 
         [HttpGet("revoke")]
         [ProducesResponseType(200, Type = typeof(ObjectResponse<string[]>))]
-        [ProducesResponseType(401, Type = typeof(ObjectResponse<HttpException>))]
-        [ProducesResponseType(404, Type = typeof(ObjectResponse<HttpException>))]
-        [ProducesResponseType(409, Type = typeof(ObjectResponse<HttpException>))]
         public ActionResult Revoke(string token, string username, string license)
         {
-            var authRes = MainClass.ValidatePermissions(token, RequiredPermissions);
-            if (authRes != null)
-            {
-                Response.StatusCode = authRes?.Data.Code ?? 0;
-                return Json(authRes, MainClass.serializerOptions);
-            }
             var tokenAccount = MainClass.contentManager.AccountManager.GetAccount(token, false);
 
             var account = MainClass.contentManager.AccountManager.GetAccountByUsername(username);

--- a/OpenSoftwareLauncher.Server/Controllers/Admin/User/UserPermissionController.cs
+++ b/OpenSoftwareLauncher.Server/Controllers/Admin/User/UserPermissionController.cs
@@ -8,26 +8,16 @@ namespace OpenSoftwareLauncher.Server.Controllers.Admin.User
 {
     [Route("admin/user/permission")]
     [ApiController]
+    [OSLAuthRequired]
+    [OSLAuthPermission(AccountPermission.USER_PERMISSION_MODIFY)]
     public class UserPermissionController : Controller
     {
-        public static AccountPermission[] RequiredPermissions = new AccountPermission[]
-        {
-            AccountPermission.USER_PERMISSION_MODIFY
-        };
-
         [HttpGet("list")]
         [ProducesResponseType(200, Type = typeof(ObjectResponse<AccountPermission[]>))]
         [ProducesResponseType(401, Type = typeof(ObjectResponse<HttpException>))]
         [ProducesResponseType(404, Type = typeof(ObjectResponse<HttpException>))]
         public ActionResult List(string token, string username)
         {
-            var authRes = MainClass.ValidatePermissions(token, RequiredPermissions);
-            if (authRes != null)
-            {
-                Response.StatusCode = authRes?.Data.Code ?? 0;
-                return Json(authRes, MainClass.serializerOptions);
-            }
-
             var account = MainClass.contentManager.AccountManager.GetAccountByUsername(username);
             if (account == null)
             {
@@ -52,12 +42,6 @@ namespace OpenSoftwareLauncher.Server.Controllers.Admin.User
         [ProducesResponseType(404, Type = typeof(ObjectResponse<HttpException>))]
         public ActionResult Grant(string token, string username, AccountPermission permission)
         {
-            var authRes = MainClass.ValidatePermissions(token, RequiredPermissions);
-            if (authRes != null)
-            {
-                Response.StatusCode = authRes?.Data.Code ?? 0;
-                return Json(authRes, MainClass.serializerOptions);
-            }
             var tokenAccount = MainClass.contentManager.AccountManager.GetAccount(token);
 
             var account = MainClass.contentManager.AccountManager.GetAccountByUsername(username);
@@ -86,12 +70,6 @@ namespace OpenSoftwareLauncher.Server.Controllers.Admin.User
         [ProducesResponseType(404, Type = typeof(ObjectResponse<HttpException>))]
         public ActionResult Revoke(string token, string username, AccountPermission permission)
         {
-            var authRes = MainClass.ValidatePermissions(token, RequiredPermissions);
-            if (authRes != null)
-            {
-                Response.StatusCode = authRes?.Data.Code ?? 0;
-                return Json(authRes, MainClass.serializerOptions);
-            }
             var tokenAccount = MainClass.contentManager.AccountManager.GetAccount(token);
 
             var account = MainClass.contentManager.AccountManager.GetAccountByUsername(username);

--- a/OpenSoftwareLauncher.Server/Controllers/Admin/User/UserTokenController.cs
+++ b/OpenSoftwareLauncher.Server/Controllers/Admin/User/UserTokenController.cs
@@ -12,24 +12,15 @@ namespace OpenSoftwareLauncher.Server.Controllers.Admin.User
 {
     [Route("admin/user/token")]
     [ApiController]
+    [OSLAuthRequired]
+    [OSLAuthPermission(AccountPermission.USER_TOKEN_PURGE)]
     public class UserTokenController : Controller
     {
-        public AccountPermission[] RequiredPermissions = new AccountPermission[]
-        {
-            AccountPermission.USER_TOKEN_PURGE
-        };
-
         [HttpGet("purge/all")]
         [ProducesResponseType(200, Type = typeof(ObjectResponse<Dictionary<string, int>>))]
         [ProducesResponseType(401, Type = typeof(ObjectResponse<HttpException>))]
         public ActionResult TokenPurgeAll(string token, bool includeGivenToken=false)
         {
-            var authRes = MainClass.ValidatePermissions(token, RequiredPermissions);
-            if (authRes != null)
-            {
-                Response.StatusCode = authRes?.Data.Code ?? 0;
-                return Json(authRes, MainClass.serializerOptions);
-            }
             var tokenAccount = MainClass.contentManager.AccountManager.GetAccount(token);
             var usernameDict = new Dictionary<string, int>();
             foreach (var user in MainClass.contentManager.AccountManager.GetAllAccounts())
@@ -60,13 +51,6 @@ namespace OpenSoftwareLauncher.Server.Controllers.Admin.User
         [ProducesResponseType(401, Type = typeof(ObjectResponse<HttpException>))]
         public ActionResult TokenPurge(string token, string? username = null, bool? isUsernameFieldRegexPattern = false)
         {
-            var authRes = MainClass.ValidatePermissions(token, RequiredPermissions);
-            if (authRes != null)
-            {
-                Response.StatusCode = authRes?.Data.Code ?? 0;
-                return Json(authRes, MainClass.serializerOptions);
-            }
-
             var tokenAccount = MainClass.contentManager.AccountManager.GetAccount(token);
 
             OSLCommon.Authorization.Account[] accountArray;

--- a/OpenSoftwareLauncher.Server/Controllers/Admin/UserController.cs
+++ b/OpenSoftwareLauncher.Server/Controllers/Admin/UserController.cs
@@ -12,6 +12,8 @@ namespace OpenSoftwareLauncher.Server.Controllers.Admin
 
     [Route("admin/[controller]")]
     [ApiController]
+    [OSLAuthRequired]
+    [OSLAuthPermission(AccountPermission.USER_LIST)]
     public class UserController : Controller
     {
         public static AccountPermission[] RequiredPermissions = new AccountPermission[]
@@ -76,15 +78,10 @@ namespace OpenSoftwareLauncher.Server.Controllers.Admin
         [HttpGet("delete")]
         [ProducesResponseType(200, Type = typeof(ObjectResponse<object>))]
         [ProducesResponseType(401, Type = typeof(ObjectResponse<HttpException>))]
+        [OSLAuthRequired]
+        [OSLAuthPermission(AccountPermission.USER_DELETE)]
         public ActionResult DeleteAccount(string token, string username)
         {
-            var authRes = MainClass.ValidatePermissions(token, AccountPermission.USER_DELETE);
-            if (authRes != null)
-            {
-                Response.StatusCode = authRes?.Data.Code ?? 0;
-                return Json(authRes, MainClass.serializerOptions);
-            }
-
             MainClass.contentManager.AccountManager.DeleteAccount(username);
             return Json(new ObjectResponse<object>()
             {
@@ -97,14 +94,10 @@ namespace OpenSoftwareLauncher.Server.Controllers.Admin
         [ProducesResponseType(200, Type = typeof(ObjectResponse<AccountDetailsResponse>))]
         [ProducesResponseType(401, Type = typeof(ObjectResponse<HttpException>))]
         [ProducesResponseType(404, Type = typeof(ObjectResponse<HttpException>))]
+        [OSLAuthRequired]
+        [OSLAuthPermission(AccountPermission.USER_DISABLE_MODIFY)]
         public ActionResult PardonState(string token, string username)
         {
-            var authRes = MainClass.ValidatePermissions(token, AccountPermission.USER_DISABLE_MODIFY);
-            if (authRes != null)
-            {
-                Response.StatusCode = authRes?.Data.Code ?? 0;
-                return Json(authRes, MainClass.serializerOptions);
-            }
             var tokenAccount = MainClass.contentManager.AccountManager.GetAccount(token);
             var targetAccount = MainClass.contentManager.AccountManager.GetAccountByUsername(username);
             if (targetAccount == null)
@@ -141,6 +134,8 @@ namespace OpenSoftwareLauncher.Server.Controllers.Admin
         [ProducesResponseType(200, Type = typeof(ObjectResponse<AccountDetailsResponse>))]
         [ProducesResponseType(401, Type = typeof(ObjectResponse<HttpException>))]
         [ProducesResponseType(404, Type = typeof(ObjectResponse<HttpException>))]
+        [OSLAuthRequired]
+        [OSLAuthPermission(AccountPermission.USER_DISABLE_MODIFY)]
         public ActionResult DisableState(string token, string username, string? reason="No reason")
         {
             var authRes = MainClass.ValidatePermissions(token, AccountPermission.USER_DISABLE_MODIFY);

--- a/OpenSoftwareLauncher.Server/Controllers/Admin/UserController.cs
+++ b/OpenSoftwareLauncher.Server/Controllers/Admin/UserController.cs
@@ -27,13 +27,6 @@ namespace OpenSoftwareLauncher.Server.Controllers.Admin
         [ProducesResponseType(401, Type = typeof(ObjectResponse<HttpException>))]
         public ActionResult List(string token, string? username=null, SearchMethod usernameSearchType = SearchMethod.Equals, long firstSeenTimestamp=0, long lastSeenTimestamp=long.MaxValue)
         {
-            var authRes = MainClass.ValidatePermissions(token, RequiredPermissions);
-            if (authRes != null)
-            {
-                Response.StatusCode = authRes?.Data.Code ?? 0;
-                return Json(authRes, MainClass.serializerOptions);
-            }
-
             var detailList = new List<AccountDetailsResponse>();
             foreach (var account in MainClass.contentManager.AccountManager.GetAllAccounts(false))
             {
@@ -138,12 +131,6 @@ namespace OpenSoftwareLauncher.Server.Controllers.Admin
         [OSLAuthPermission(AccountPermission.USER_DISABLE_MODIFY)]
         public ActionResult DisableState(string token, string username, string? reason="No reason")
         {
-            var authRes = MainClass.ValidatePermissions(token, AccountPermission.USER_DISABLE_MODIFY);
-            if (authRes != null)
-            {
-                Response.StatusCode = authRes?.Data.Code ?? 0;
-                return Json(authRes, MainClass.serializerOptions);
-            }
             var bannerAccount = MainClass.contentManager.AccountManager.GetAccount(token);
             var targetAccount = MainClass.contentManager.AccountManager.GetAccountByUsername(username);
             if (targetAccount == null)

--- a/OpenSoftwareLauncher.Server/Controllers/Admin/UserController.cs
+++ b/OpenSoftwareLauncher.Server/Controllers/Admin/UserController.cs
@@ -25,6 +25,8 @@ namespace OpenSoftwareLauncher.Server.Controllers.Admin
         [Route("list")]
         [ProducesResponseType(200, Type = typeof(ObjectResponse<AccountDetailsResponse[]>))]
         [ProducesResponseType(401, Type = typeof(ObjectResponse<HttpException>))]
+        [OSLAuthRequired]
+        [OSLAuthPermission(AccountPermission.USER_LIST)]
         public ActionResult List(string token, string? username=null, SearchMethod usernameSearchType = SearchMethod.Equals, long firstSeenTimestamp=0, long lastSeenTimestamp=long.MaxValue)
         {
             var detailList = new List<AccountDetailsResponse>();

--- a/OpenSoftwareLauncher.Server/Controllers/AuditLogController.cs
+++ b/OpenSoftwareLauncher.Server/Controllers/AuditLogController.cs
@@ -13,15 +13,10 @@ namespace OpenSoftwareLauncher.Server.Controllers
         [HttpGet("fetch")]
         [ProducesResponseType(200, Type = typeof(ObjectResponse<AuditLogEntry[]>))]
         [ProducesResponseType(401, Type = typeof(ObjectResponse<HttpException>))]
+        [OSLAuthPermission(AccountPermission.AUDITLOG_SELF)]
+        [OSLAuthRequired]
         public ActionResult FetchAll(string token)
         {
-            var authRes = MainClass.ValidatePermissions(token, AccountPermission.AUDITLOG_SELF);
-            if (authRes != null)
-            {
-                Response.StatusCode = authRes?.Data.Code ?? 0;
-                return Json(authRes, MainClass.serializerOptions);
-            }
-
             var account = MainClass.contentManager.AccountManager.GetAccount(token);
 
             var result = MainClass.contentManager.AuditLogManager.GetByUsername(account.Username).Result;

--- a/OpenSoftwareLauncher.Server/Controllers/FileController.cs
+++ b/OpenSoftwareLauncher.Server/Controllers/FileController.cs
@@ -79,17 +79,12 @@ namespace OpenSoftwareLauncher.Server.Controllers
         [HttpGet("{hash}")]
         [ProducesResponseType(401, Type = typeof(ObjectResponse<HttpException>))]
         [ProducesResponseType(200, Type = typeof(List<PublishedReleaseFile>))]
+        [OSLAuthRequired]
         public ActionResult FetchFilesFromHash(string hash, string token)
         {
             var returnContent = new List<PublishedReleaseFile>();
             var contentManager = MainClass.contentManager;
 
-            var authRes = MainClass.Validate(token);
-            if (authRes != null)
-            {
-                Response.StatusCode = authRes?.Data.Code ?? 0;
-                return Json(authRes, MainClass.serializerOptions);
-            }
             var account = MainClass.contentManager.AccountManager.GetAccount(token, true);
 
             if (contentManager != null)
@@ -135,6 +130,7 @@ namespace OpenSoftwareLauncher.Server.Controllers
         [HttpGet("")]
         [ProducesResponseType(401, Type = typeof(ObjectResponse<HttpException>))]
         [ProducesResponseType(200, Type = typeof(List<PublishedReleaseFile>))]
+        [OSLAuthRequired]
         public ActionResult FetchFilesFromHashByParameter(string hash, string? token = "") => FetchFilesFromHash(hash, token ?? "");
     }
 }

--- a/OpenSoftwareLauncher.Server/Controllers/LicenseController.cs
+++ b/OpenSoftwareLauncher.Server/Controllers/LicenseController.cs
@@ -12,14 +12,9 @@ namespace OpenSoftwareLauncher.Server.Controllers
         [HttpGet("redeem")]
         [ProducesResponseType(200, Type = typeof(ObjectResponse<GrantLicenseKeyResponse>))]
         [ProducesResponseType(401, Type = typeof(ObjectResponse<HttpException>))]
+        [OSLAuthRequired]
         public ActionResult Redeem(string token, string key)
         {
-            var authRes = MainClass.Validate(token);
-            if (authRes != null)
-            {
-                Response.StatusCode = authRes?.Data.Code ?? 0;
-                return Json(authRes, MainClass.serializerOptions);
-            }
             var account = MainClass.contentManager.AccountManager.GetAccount(token);
             var data = MainClass.contentManager.AccountLicenseManager.GetLicenseKey(key).Result;
             if (data == null)

--- a/OpenSoftwareLauncher.Server/Controllers/PublishController.cs
+++ b/OpenSoftwareLauncher.Server/Controllers/PublishController.cs
@@ -152,20 +152,10 @@ namespace OpenSoftwareLauncher.Server.Controllers
         [HttpGet("hash")]
         [ProducesResponseType(401, Type = typeof(HttpException))]
         [ProducesResponseType(200, Type = typeof(ObjectResponse<PublishedRelease?>))]
+        [OSLAuthRequired]
+        [OSLAuthPermission(AccountPermission.ADMINISTRATOR)]
         public ActionResult ByCommitHashFromParameter(string hash, string? token)
         {
-            var account = MainClass.contentManager.AccountManager.GetAccount(token ?? "", bumpLastUsed: true);
-            if (account == null)
-            {
-                Response.StatusCode = 401;
-                return Json(new HttpException(401, ServerStringResponse.InvalidCredential), MainClass.serializerOptions);
-            }
-            if (!account.HasPermission(AccountPermission.ADMINISTRATOR))
-            {
-                Response.StatusCode = 401;
-                return Json(new HttpException(401, @"Missing permissions"), MainClass.serializerOptions);
-            }
-
             PublishedRelease? commit = MainClass.contentManager?.GetPublishedReleaseByHash(hash);
             return Json(new ObjectResponse<PublishedRelease?>()
             {
@@ -177,6 +167,8 @@ namespace OpenSoftwareLauncher.Server.Controllers
         [HttpGet("hash/{hash}")]
         [ProducesResponseType(401, Type = typeof(HttpException))]
         [ProducesResponseType(200, Type = typeof(ObjectResponse<PublishedRelease?>))]
+        [OSLAuthRequired]
+        [OSLAuthPermission(AccountPermission.ADMINISTRATOR)]
         public ActionResult ByCommitHashFromPath(string? token, string hash) => ByCommitHashFromParameter(token ?? "", hash);
     }
 }

--- a/OpenSoftwareLauncher.Server/Controllers/ReleaseController.cs
+++ b/OpenSoftwareLauncher.Server/Controllers/ReleaseController.cs
@@ -292,15 +292,10 @@ namespace OpenSoftwareLauncher.Server.Controllers
         [HttpGet("history/at")]
         [ProducesResponseType(200, Type = typeof(ObjectResponse<List<ProductReleaseStream>>))]
         [ProducesResponseType(401, Type = typeof(ObjectResponse<HttpException>))]
+        [OSLAuthRequired]
+        [OSLAuthPermission(AccountPermission.READ_RELEASE_HISTORY)]
         public ActionResult FromCommitHash(string token, string hash, string? signature = "")
         {
-            var validationResponse = MainClass.ValidatePermissions(token, AccountPermission.READ_RELEASE_HISTORY);
-            if (validationResponse != null)
-            {
-                Response.StatusCode = validationResponse.Data.Code;
-                return Json(validationResponse, MainClass.serializerOptions);
-            }
-
             OSLCommon.Authorization.Account account = MainClass.contentManager.AccountManager.GetAccount(token);
 
             var collection = MainClass.contentManager.GetReleaseCollection();
@@ -335,15 +330,10 @@ namespace OpenSoftwareLauncher.Server.Controllers
         [HttpGet("history/sig")]
         [ProducesResponseType(200, Type = typeof(ObjectResponse<List<ProductReleaseStream>>))]
         [ProducesResponseType(401, Type = typeof(ObjectResponse<HttpException>))]
+        [OSLAuthRequired]
+        [OSLAuthPermission(AccountPermission.READ_RELEASE_HISTORY)]
         public ActionResult FromSignature(string token, string signature)
         {
-            var validationResponse = MainClass.ValidatePermissions(token, AccountPermission.READ_RELEASE_HISTORY);
-            if (validationResponse != null)
-            {
-                Response.StatusCode = validationResponse.Data.Code;
-                return Json(validationResponse, MainClass.serializerOptions);
-            }
-
             OSLCommon.Authorization.Account account = MainClass.contentManager.AccountManager.GetAccount(token);
 
             var collection = MainClass.contentManager.GetReleaseCollection();

--- a/OpenSoftwareLauncher.Server/Controllers/TokenController.cs
+++ b/OpenSoftwareLauncher.Server/Controllers/TokenController.cs
@@ -140,12 +140,6 @@ namespace OpenSoftwareLauncher.Server.Controllers
         [OSLAuthRequiredAttribute]
         public ActionResult Reset(string token, bool? all = false)
         {
-            var authRes = MainClass.Validate(token);
-            if (authRes != null)
-            {
-                Response.StatusCode = authRes?.Data.Code ?? 0;
-                return Json(authRes, MainClass.serializerOptions);
-            }
             var account = MainClass.contentManager.AccountManager.GetAccount(token, true);
 
             if (all ?? false)

--- a/OpenSoftwareLauncher.Server/Controllers/TokenController.cs
+++ b/OpenSoftwareLauncher.Server/Controllers/TokenController.cs
@@ -71,6 +71,7 @@ namespace OpenSoftwareLauncher.Server.Controllers
         [HttpGet("validate")]
         [ProducesResponseType(StatusCodes.Status401Unauthorized, Type = typeof(ObjectResponse<bool>))]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(ObjectResponse<bool>))]
+        [OSLAuthRequiredAttribute]
         public ActionResult Validate(string token)
         {
             if (token.Length < 32 || token.Length > 32)
@@ -110,14 +111,9 @@ namespace OpenSoftwareLauncher.Server.Controllers
         [HttpGet("details")]
         [ProducesResponseType(200, Type = typeof(ObjectResponse<AccountTokenDetailsResponse>))]
         [ProducesResponseType(401, Type = typeof(ObjectResponse<HttpException>))]
+        [OSLAuthRequiredAttribute]
         public ActionResult Details(string token)
         {
-            var authRes = MainClass.Validate(token);
-            if (authRes != null)
-            {
-                Response.StatusCode = authRes?.Data.Code ?? 0;
-                return Json(authRes, MainClass.serializerOptions);
-            }
             var account = MainClass.contentManager.AccountManager.GetAccount(token, true);
 
             var details = account.GetTokenDetails(token);
@@ -141,6 +137,7 @@ namespace OpenSoftwareLauncher.Server.Controllers
         [HttpGet("remove")]
         [ProducesResponseType(200, Type = typeof(ObjectResponse<object>))]
         [ProducesResponseType(401, Type = typeof(ObjectResponse<HttpException>))]
+        [OSLAuthRequiredAttribute]
         public ActionResult Reset(string token, bool? all = false)
         {
             var authRes = MainClass.Validate(token);

--- a/OpenSoftwareLauncher.Server/MainClass.cs
+++ b/OpenSoftwareLauncher.Server/MainClass.cs
@@ -201,58 +201,6 @@ namespace OpenSoftwareLauncher.Server
             App.MapControllers();
             App.Run();
         }
-        public static ObjectResponse<HttpException>? Validate(string token)
-        {
-            var tokenAccount = MainClass.contentManager.AccountManager.GetAccount(token, bumpLastUsed: true);
-            if (tokenAccount == null)
-            {
-                return new ObjectResponse<HttpException>()
-                {
-                    Success = false,
-                    Data = new HttpException(StatusCodes.Status401Unauthorized, ServerStringResponse.InvalidCredential)
-                };
-            }
-            if (!tokenAccount.Enabled)
-            {
-                return new ObjectResponse<HttpException>()
-                {
-                    Success = false,
-                    Data = new HttpException(StatusCodes.Status401Unauthorized, ServerStringResponse.AccountDisabled + "\n====Reason====\n" + tokenAccount.DisableReasons.OrderBy(v => v.Timestamp).First()?.Message)
-                };
-            }
-            return null;
-        }
-        public static ObjectResponse<HttpException>? ValidatePermissions(string token, AccountPermission[] permissions)
-        {
-            if (!contentManager.AccountManager.AccountHasPermission(token, permissions))
-            {
-                return new ObjectResponse<HttpException>()
-                {
-                    Success = false,
-                    Data = new HttpException(StatusCodes.Status401Unauthorized, ServerStringResponse.InvalidCredential)
-                };
-            }
-            var tokenAccount = MainClass.contentManager.AccountManager.GetAccount(token, bumpLastUsed: true);
-            if (tokenAccount == null)
-            {
-                return new ObjectResponse<HttpException>()
-                {
-                    Success = false,
-                    Data = new HttpException(StatusCodes.Status401Unauthorized, ServerStringResponse.InvalidCredential)
-                };
-            }
-            if (!tokenAccount.Enabled)
-            {
-                return new ObjectResponse<HttpException>()
-                {
-                    Success = false,
-                    Data = new HttpException(StatusCodes.Status401Unauthorized, ServerStringResponse.AccountDisabled + "\n====Reason====\n" + tokenAccount.DisableReasons.OrderBy(v => v.Timestamp).First()?.Message)
-                };
-            }
-            return null;
-        }
-        public static ObjectResponse<HttpException>? ValidatePermissions(string token, AccountPermission permission)
-            => ValidatePermissions(token, new AccountPermission[] { permission });
 
         public static void BeforeExit(object sender, EventArgs e)
         {

--- a/OpenSoftwareLauncher.Server/OSLAuthPermissionAttribute.cs
+++ b/OpenSoftwareLauncher.Server/OSLAuthPermissionAttribute.cs
@@ -21,8 +21,10 @@ namespace OpenSoftwareLauncher.Server
         }
         public OSLAuthPermissionAttribute(AccountPermission permission)
         {
-            AccountPermissions = new List<AccountPermission>();
-            AccountPermissions.Add(permission);
+            AccountPermissions = new List<AccountPermission>
+            {
+                permission
+            };
         }
 
         public override void OnActionExecuting(ActionExecutingContext context)
@@ -36,14 +38,22 @@ namespace OpenSoftwareLauncher.Server
                     if (account.Enabled)
                     {
                         bool has = false;
-                        foreach (var perm in AccountPermissions)
+                        if (account.Permissions.Contains(AccountPermission.ADMINISTRATOR))
                         {
-                            if (account.HasPermission(perm))
+                            has = true;
+                        }
+                        else
+                        {
+                            foreach (var perm in AccountPermissions)
                             {
-                                has = true;
-                                break;
+                                if (account.HasPermission(perm))
+                                {
+                                    has = true;
+                                    break;
+                                }
                             }
                         }
+
                         if (has)
                         {
                             base.OnActionExecuting(context);

--- a/OpenSoftwareLauncher.Server/OSLAuthPermissionAttribute.cs
+++ b/OpenSoftwareLauncher.Server/OSLAuthPermissionAttribute.cs
@@ -4,20 +4,22 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using OSLCommon;
 using OSLCommon.Authorization;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
 namespace OpenSoftwareLauncher.Server
 {
-    public class OSLAuthFilter : ActionFilterAttribute
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+    public class OSLAuthPermissionAttribute : ActionFilterAttribute
     {
         public List<AccountPermission> AccountPermissions;
-        public OSLAuthFilter(AccountPermission[] permissions)
+        public OSLAuthPermissionAttribute(AccountPermission[] permissions)
         {
             AccountPermissions = new List<AccountPermission>();
             AccountPermissions.AddRange(permissions);
         }
-        public OSLAuthFilter(AccountPermission permission)
+        public OSLAuthPermissionAttribute(AccountPermission permission)
         {
             AccountPermissions = new List<AccountPermission>();
             AccountPermissions.Add(permission);

--- a/OpenSoftwareLauncher.Server/OSLAuthRequiredAttribute.cs
+++ b/OpenSoftwareLauncher.Server/OSLAuthRequiredAttribute.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using OSLCommon;
+using System;
+using System.Linq;
+
+namespace OpenSoftwareLauncher.Server
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+    public class OSLAuthRequiredAttribute : ActionFilterAttribute
+    {
+        public override void OnActionExecuting(ActionExecutingContext context)
+        {
+            if (context.HttpContext.Request.Query.ContainsKey("token"))
+            {
+                var token = context.HttpContext.Request.Query["token"].ToString();
+                var account = MainClass.contentManager.AccountManager.GetAccount(token);
+                if (account != null && account.Enabled)
+                {
+                    base.OnActionExecuting(context);
+                    return;
+                }
+                if (account != null)
+                {
+                    if (account.Enabled)
+                    {
+                        base.OnActionExecuting(context);
+                        return;
+                    }
+                    context.HttpContext.Response.StatusCode = StatusCodes.Status401Unauthorized;
+                    context.Result = new JsonResult(new ObjectResponse<HttpException>()
+                    {
+                        Success = false,
+                        Data = new HttpException(StatusCodes.Status401Unauthorized, ServerStringResponse.AccountDisabled + "\n====Reason====\n" + account.DisableReasons.OrderBy(v => v.Timestamp).First()?.Message)
+                    }, MainClass.serializerOptions);
+                }
+            }
+
+            context.HttpContext.Response.StatusCode = StatusCodes.Status401Unauthorized;
+            context.Result = new JsonResult(new ObjectResponse<HttpException>()
+            {
+                Success = false,
+                Data = new HttpException(StatusCodes.Status401Unauthorized, ServerStringResponse.InvalidCredential)
+            }, MainClass.serializerOptions);
+        }
+    }
+}


### PR DESCRIPTION
Use custom attributes on routes to enforce account permissions and requirements in a more clean way. By doing this, a lot of useless duplicated code is removed.